### PR TITLE
Introduce the 'untouchable_groups' concept (cf. _role_policy_untoucha…

### DIFF
--- a/role_policy/models/base.py
+++ b/role_policy/models/base.py
@@ -11,6 +11,19 @@ _logger = logging.getLogger(__name__)
 class BaseModel(models.AbstractModel):
     _inherit = "base"
 
+    def _role_policy_untouchable_groups(self):
+        """
+        The role policy will remove all groups from the fields
+        except the ones defined in this method.
+        """
+        return [
+            "base.group_no_one",
+            "base.group_erp_manager",
+            "base.group_system",
+            "base.group_portal",
+            "base.group_public",
+        ]
+
     @api.model
     def user_has_groups(self, groups):
         """
@@ -27,13 +40,7 @@ class BaseModel(models.AbstractModel):
         role_groups = []
         for group_ext_id in groups.split(","):
             xml_id = group_ext_id[0] == "!" and group_ext_id[1:] or group_ext_id
-            if xml_id in [
-                "base.group_no_one",
-                "base.group_erp_manager",
-                "base.group_system",
-                "base.group_portal",
-                "base.group_public",
-            ]:
+            if xml_id in self._role_policy_untouchable_groups():
                 role_groups.append(group_ext_id)
             else:
                 group = self.env.ref(xml_id)


### PR DESCRIPTION
…ble_groups method):

This is a list of groups that are NOT removed by the view and field level groups definitions.
This list is now used consistently in the view rendering.
By doing so the 'developper mode' behaviour is restored.
It also fixes screen rendering issues on fields with an 'untouchable' group defined on a field via the field level groups parameter (e.g. ir.actions.server: code = fields.Text(string='Python Code', groups='base.group_system',...).