### PR TITLE
[13.0]role_policy - fix user update

### DIFF
--- a/role_policy/models/res_users.py
+++ b/role_policy/models/res_users.py
@@ -108,7 +108,7 @@ class ResUsers(models.Model):
         if config.get("test_enable"):
             return super().write(vals)
 
-        if vals.get("enabled_role_ids"):
+        if vals.get("role_ids") or vals.get("enabled_role_ids"):
             self.clear_caches()
         vals = self._remove_reified_groups(vals)
         if not any(

--- a/role_policy/models/res_users.py
+++ b/role_policy/models/res_users.py
@@ -108,8 +108,6 @@ class ResUsers(models.Model):
         if config.get("test_enable"):
             return super().write(vals)
 
-        if vals.get("role_ids") or vals.get("enabled_role_ids"):
-            self.clear_caches()
         vals = self._remove_reified_groups(vals)
         if not any(
             [vals.get(x) for x in ("groups_id", "role_ids", "enabled_role_ids")]
@@ -235,3 +233,4 @@ class ResUsers(models.Model):
 
         if group_updates:
             super(ResUsersBase, self.sudo()).write({"groups_id": group_updates})
+            self.clear_caches()

--- a/role_policy/models/res_users.py
+++ b/role_policy/models/res_users.py
@@ -1,6 +1,8 @@
 # Copyright 2020-2021 Noviat
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from lxml import etree
 
 from odoo import api, fields, models
@@ -9,6 +11,8 @@ from odoo.tools import config
 from odoo.addons.base.models.res_users import Users as ResUsersBase
 
 from .helpers import diff_to_odoo_x2many_commands, play_odoo_x2x_commands_on_ids
+
+_logger = logging.getLogger(__name__)
 
 
 class ResUsers(models.Model):
@@ -184,40 +188,50 @@ class ResUsers(models.Model):
         remove role ACL groups when removing/disabling roles
         """
         self.ensure_one()
+        group_updates = vals.get("groups_id")
+        vals.pop("groups_id", None)
+        role_updates = vals.get("role_ids", [])
+        enabled_role_updates = vals.get("enabled_role_ids", [])
         keep_gids = self._get_role_policy_group_keep_ids()
 
         # remove no role groups
         target_gids = set(self.groups_id.ids)
-        if "groups_id" in vals:
-            target_gids = play_odoo_x2x_commands_on_ids(target_gids, vals["groups_id"])
-            del vals["groups_id"]
+        if group_updates:
+            target_gids = play_odoo_x2x_commands_on_ids(target_gids, group_updates)
         target_gids = {x for x in target_gids if x in keep_gids}
 
-        # remove role ACL groups when removing/disabling roles
-        target_rids = set()
-        if vals.get("enabled_role_ids"):
-            target_rids = play_odoo_x2x_commands_on_ids(
-                target_rids, vals["enabled_role_ids"]
+        # remove enabled roles that are no longer in roles
+        current_rids = new_rids = set(self.role_ids.ids)
+        current_enabled_rids = new_enabled_rids = set(self.enabled_role_ids.ids)
+        if role_updates:
+            new_rids = play_odoo_x2x_commands_on_ids(current_rids, role_updates)
+        if enabled_role_updates:
+            new_enabled_rids = play_odoo_x2x_commands_on_ids(
+                current_enabled_rids, enabled_role_updates
             )
-        if not target_rids:
-            if vals.get("role_ids"):
-                target_rids = play_odoo_x2x_commands_on_ids(
-                    target_rids, vals["role_ids"]
-                )
-            else:
-                target_rids = set(self.role_ids.ids)
+        new_enabled_rids &= new_rids
+
+        # remove role ACL groups when removing/disabling roles
+        target_rids = new_enabled_rids or new_rids
         if target_rids:
             enabled_roles = self.env["res.role"].browse(target_rids)
             enabled_role_groups = enabled_roles.mapped("group_id")
             enabled_role_groups |= enabled_role_groups.mapped("implied_ids")
             target_gids |= set(enabled_role_groups.ids)
+        group_updates = diff_to_odoo_x2many_commands(self.groups_id.ids, target_gids)
 
-        groups_updates = diff_to_odoo_x2many_commands(self.groups_id.ids, target_gids)
-
+        vals["role_ids"] = diff_to_odoo_x2many_commands(self.role_ids.ids, new_rids)
+        vals["enabled_role_ids"] = diff_to_odoo_x2many_commands(
+            self.enabled_role_ids.ids, new_enabled_rids
+        )
+        # empty 'commands' on x2M fields (e.g. vals["role_ids"] = []) should not
+        # have any effect but the ORM seems to handle these as a regular write
+        # hence we hit an ACL error on fields that do not belong to the
+        # SELF_WRITEABLE_FIELDS.
+        for fld in ("role_ids", "enabled_role_ids"):
+            if vals.get(fld) == []:
+                del vals[fld]
         super().write(vals)
 
-        if groups_updates:
-            super(ResUsersBase, self.sudo()).write({"groups_id": groups_updates})
-        if "role_ids" in vals:
-            ctx = dict(self.env.context, role_policy_bypass_write=True)
-            self.with_context(ctx)._onchange_role_ids()
+        if group_updates:
+            super(ResUsersBase, self.sudo()).write({"groups_id": group_updates})

--- a/role_policy/models/view_type_attribute.py
+++ b/role_policy/models/view_type_attribute.py
@@ -56,17 +56,21 @@ class ViewTypeAttribute(models.Model):
         user_roles = self.env.user.enabled_role_ids or self.env.user.role_ids
         dom = [("view_id", "=", view_id), ("role_id", "in", user_roles.ids)]
         all_rules = self.search(dom)
-        all_rules = all_rules.sorted(key=lambda r: (r.attrib or "", r.priority))
-        if all_rules:
-            for i, rule in enumerate(all_rules):
-                if i == 0:
-                    rules = rule
-                    previous_signature = [getattr(rule, f) for f in signature_fields]
-                else:
-                    signature = [getattr(rule, f) for f in signature_fields]
-                    if signature != previous_signature:
-                        rules += rule
-                    previous_signature = signature
+        rules_dict = {}
+        for rule in all_rules:
+            key = "-".join([str(getattr(rule, f)) for f in signature_fields])
+            if key not in rules_dict:
+                rules_dict[key] = rule
+            else:
+                rules_dict[key] += rule
+        # Keep only rules with highest priority.
+        # No rule for one of the user roles is considered highest priority
+        roles_nbr = len(user_roles)
+        for key in rules_dict:
+            key_rules = rules_dict[key]
+            if len(key_rules) != roles_nbr:
+                continue
+            rules += key_rules.sorted(lambda r: r.priority)[0]
         return rules
 
     def _rule_signature_fields(self):


### PR DESCRIPTION
This PR fixes the following issues:

1) role change by security officer resulting in ACL error
Starting position : user with 2 roles : R1 and R2, whereby only R2 has been enabled by the user.
All ACL groups were been removed at login time after removal by the security officer of role R1.
This PR now correctly removes R2 from the 'enabled_role_ids' and restores the ACLs to those of the remaining role R1.

2) 'empty' M2M write on user.role_ids resulting in ACL error
We are using the role_policy in combination with a central security server.
At every login the user roles are retrieved from this central server and roles are updated in case of changes.
The code doing this has the following write vals in case of no changes: vals["role_ids"] = []
Since role_ids is an M2M field such a write should not result in any real update but after a git pull to update the Odoo code to the latest git level, this write results in an ACL error because the 'role_ids' field does not belong to the SELF_WRITEABLE_FIELDS.
The fix for this issue consists of removing such an empty write before passing it to the write method.

3) rule selection when multiple roles
When a user has multiple roles a "no rule" condition for one of the roles has priority over a rule for the View Modifier Rules, View Type Attributes and View Model Operations (hence the default views on the model are used for the combined rule).

4) clear_caches after every res.users,groups_id update