### PR TITLE
[13.0]role_policy - allow adding client actions via UI

### DIFF
--- a/role_policy/views/res_role_views.xml
+++ b/role_policy/views/res_role_views.xml
@@ -101,7 +101,11 @@
                         </page>
                         <page string="Client Action Bindings" id="act_client_ids">
                             <field name="act_client_ids">
-                                <tree default_order="model_name, name, xml_id" create="true" delete="true">
+                                <tree
+                                    default_order="model_name, name, xml_id"
+                                    create="true"
+                                    delete="true"
+                                >
                                     <field name="name" />
                                     <field name="xml_id" />
                                 </tree>

--- a/role_policy/views/res_role_views.xml
+++ b/role_policy/views/res_role_views.xml
@@ -101,7 +101,7 @@
                         </page>
                         <page string="Client Action Bindings" id="act_client_ids">
                             <field name="act_client_ids">
-                                <tree default_order="model_name, name, xml_id">
+                                <tree default_order="model_name, name, xml_id" create="true" delete="true">
                                     <field name="name" />
                                     <field name="xml_id" />
                                 </tree>
@@ -116,7 +116,7 @@
                                 </tree>
                             </field>
                         </page>
-                        <page string="Report Action Bindings" id="act_server_ids">
+                        <page string="Report Action Bindings" id="act_report_ids">
                             <field name="act_report_ids">
                                 <tree default_order="model, name, report_type">
                                     <field name="model" />


### PR DESCRIPTION
The ir.actions.client object has no CRUD ACL for the admin user (base.group_erp_manager).
The result is that client action can only be set via import/export.
By setting edit="true" delete="true" on the view we bypass this strange behaviour of this M2M field.