### PR TITLE
[IMP] role_policy - add 'roles' attribute to views

### DIFF
--- a/role_policy/__manifest__.py
+++ b/role_policy/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2020-2021 Noviat
+# Copyright 2020-2024 Noviat
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "Role Policy",
-    "version": "13.0.0.7.2",
+    "version": "13.0.1.0.0",
     "license": "AGPL-3",
     "author": "Noviat, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/role-policy",

--- a/role_policy/models/res_users.py
+++ b/role_policy/models/res_users.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Noviat
+# Copyright 2020-2024 Noviat
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -135,6 +135,10 @@ class ResUsers(models.Model):
             return super()._has_group(group_ext_id)
         else:
             return True
+
+    def has_role(self, code):
+        roles = self.env.user.enabled_role_ids or self.env.user.role_ids
+        return code in roles.mapped("code")
 
     @api.model
     def fields_view_get(

--- a/role_policy/readme/DESCRIPTION.rst
+++ b/role_policy/readme/DESCRIPTION.rst
@@ -45,6 +45,21 @@ In the current version of this module, view access is as a consequence secured b
 - menu items
 
 Also the groups inside view architecture are removed at view loading time.
+
+In order to compensate for the capability to add groups on view elements a new
+attribute has been added: "roles" with attritue value a list of role codes.
+
+The roles attribute works similar as the groups attribute:
+the view element will be removed if a user does not belong to one of the specified roles.
+
+|
+
+Syntax:
+
+.. code-block:: xml
+
+  <button roles="R1, R2" name="button_name" type="object" />
+
 The View Modifier Rules must be used in order to hide view elements.
 
 View Modifier Rules


### PR DESCRIPTION
In order to compensate for the capability to add groups on view elements a new attribute has been added: "roles" with attritue value a list of role codes.

The roles attribute works similar as the groups attribute: the view element will be removed if a user does not belong to one of the specified roles.