### PR TITLE
[FIX]export role

### DIFF
--- a/role_policy/report/role_policy_export_xls.py
+++ b/role_policy/report/role_policy_export_xls.py
@@ -415,7 +415,7 @@ class RolePolicyExportXls(models.AbstractModel):
             },
             "view_type": {
                 "header": {"value": "View Type"},
-                "data": {"value": self._render("rule.view_id.type or ''")},
+                "data": {"value": self._render("rule.view_type or ''")},
                 "width": 10,
             },
             "element": {


### PR DESCRIPTION
module: role_policy/report/role_policy_export_xls
Fix export of view.modifier.rule,view_type field.
This field was not exported when no view was defined.