### PR TITLE
[FIX]role_policy_hr : fix hr_employee access

### DIFF
--- a/role_policy_hr/__init__.py
+++ b/role_policy_hr/__init__.py
@@ -1,1 +1,1 @@
-# from . import models
+from . import models

--- a/role_policy_hr/models/__init__.py
+++ b/role_policy_hr/models/__init__.py
@@ -1,0 +1,1 @@
+from . import base

--- a/role_policy_hr/models/base.py
+++ b/role_policy_hr/models/base.py
@@ -1,0 +1,18 @@
+# Copyright 2009-2024 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class BaseModel(models.AbstractModel):
+    _inherit = "base"
+
+    def _role_policy_untouchable_groups(self):
+        """
+        An employee record is stored in the database via the hr_employee table
+        but only a subset of these fields are available to the regular users.
+        Only users belonging to the "hr.group_hr_user" can retrieve all fields.
+        """
+        res = super()._role_policy_untouchable_groups()
+        res.append("hr.group_hr_user")
+        return res


### PR DESCRIPTION
An employee record is stored in the database via the hr_employee table but only a subset of these fields are available to the regular users. Only users belonging to the "hr.group_hr_user" can retrieve all fields. This commit adds "hr.group_hr_user" to the role policy untouchable groups.